### PR TITLE
Reads controller's path for initial dir

### DIFF
--- a/lib/file_manager.dart
+++ b/lib/file_manager.dart
@@ -233,7 +233,7 @@ class FileManager extends StatefulWidget {
   }
 
   /// Return file extension as String.
-  /// 
+  ///
   /// ie:- `File("/../image.png")` to `"png"`
   static String getFileExtension(FileSystemEntity file) {
     if (file is File) {
@@ -271,6 +271,8 @@ class FileManager extends StatefulWidget {
 }
 
 class _FileManagerState extends State<FileManager> {
+  Future<List<Directory>?>? currentDir;
+
   @override
   void dispose() {
     widget.controller.dispose();
@@ -278,9 +280,19 @@ class _FileManagerState extends State<FileManager> {
   }
 
   @override
+  void initState() {
+    super.initState();
+    if (widget.controller.getCurrentPath.isNotEmpty) {
+      currentDir = Future.value([widget.controller.getCurrentDirectory]);
+    } else {
+      currentDir = FileManager.getStorageList();
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     return FutureBuilder<List<Directory>?>(
-      future: FileManager.getStorageList(),
+      future: currentDir,
       builder: (context, snapshot) {
         if (snapshot.hasData) {
           widget.controller.setCurrentPath = snapshot.data!.first.path;


### PR DESCRIPTION
## Status
READY

## Breaking Changes
NO

## Description
Reads dir from controller to let developer specify initial path before displaying (#16)
so that we can use 
`controller.openDirectory(Directory(rootfolder));`
in the widget's initState()
to specify initial dir before build()

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore